### PR TITLE
Fix XDip1 Sudipfilt Demo for clarity

### DIFF
--- a/src/demos/Filtering/Sudipfilt/XDip1
+++ b/src/demos/Filtering/Sudipfilt/XDip1
@@ -18,14 +18,13 @@ amps=1,0,0,1	# In this demo, we try to kill a reflector of given slope
 # the steepest reflector is spatially aliased.
 #
 # In this demo, we "fool the program" (see the sudipfilt self-doc)
-# by using nominal units in sudipfilt.  The data is created with
-# "physical" parameters of dt=4ms and (nominally) dx=d2=0.016km=16m:
+# by using nominal units in sudipfilt.  The data "physical" parameters 
+# of dt=4ms and offset=400 are ignored.
 dt=1
 dx=1
 
 # First make the synthetic data for the dip filtering demo.
-# Assume that trace spacing is measured in km.
-suplane | sushw key=d2 a=0.016 >suplane.data
+suplane > suplane.data
 
 # Plot the model 
 suxwigb <suplane.data title="Data: 3 sloping reflectors--Use dt=dx=1" \
@@ -66,7 +65,7 @@ suxwigb title="slope=$slopes amps=$amps bias=$bias" \
 # Failed because steep reflector is spatially aliased.  Here the
 # bias parameter can help (see the sudipfilt self-doc).  Look at
 # the F-K spectrum:
-suspecfk <suplane.data |
+suspecfk <suplane.data dt=$dt dx=$dx |
 suxwigb title="F-K Spectrum of Data" \
 	windowtitle="F-K" \
 	label1="Frequency" label2="K"\


### PR DESCRIPTION
Hello my legend John W Stockwell Jr!

I remember of you from my class when we used SU in college and I still do remember.
It's an honor to make this pull request and congratulations for the repository now in GitHub. 

I hope I am not doing anything wrong or missing something. Well I also not sure if it's a good contribution but personally that modification was necessary to explain to my intern how the `sudipfilt` worked. If you find it useful here is this pull request. 

I just made a little modification on the demo example about the `sudipfilt`.

> Add the dt=$dt dx=$dx on the F-K spectrum to make it coherent with the rest of the example. 
> Also rephrase the paragraph about the nominal units for sudipfilt.