### PR TITLE
fix open error, Record length parameter,RECL=, only for ACCESS=DIRECT

### DIFF
--- a/src/Fortran/Raytrace3D/util_drt.f
+++ b/src/Fortran/Raytrace3D/util_drt.f
@@ -96,12 +96,11 @@ c23456789012345678901234567890123456789012345678901234567890123456789012
 
       if (form .eq. 'direct' .or. form .eq. 'DIRECT') then
 
-        open(i_file,file=file,status=status,form=form,err=999)
+        open(i_file,file=file,status=status,form=form,recl=n_rec,err=999)
 
       else
 
-        open(i_file,file=file,status=status,form=form
-     1,recl=n_rec,err=999)
+        open(i_file,file=file,status=status,form=form,err=999)
 
       endif
 


### PR DESCRIPTION
Raytrace3D code fails when opening file. Fortran runtime error. 

According to https://docs.oracle.com/cd/E19957-01/805-4939/6j4m0vnaf/index.html parameter recl= should only be used when access=direct. 

if-statement in original code seem to be switched..