### PR TITLE
seg2segy use of tmpnam()

### DIFF
--- a/src/Third_Party/seg2segy/seg2segy.c
+++ b/src/Third_Party/seg2segy/seg2segy.c
@@ -303,8 +303,21 @@ NULL};
 
 	char tmpfilename[L_tmpnam];
 	FILE *tmpfileptr;
-
-	tmpnam(tmpfilename);
+#ifdef __MSDOS__
+	/* MSDOS doesn't seem to have a tmpnam_s() so continue to use the tmpnam() 
+         * function.  tmpnam_s() is available on WIN32 with possible code:
+         * errno_t err;
+         * err = tmpnam_s(tmpfilename, L_tmpnam);
+         * if (err)
+         * {
+         * printf("Error occurred creating temp file.\n");
+         * exit(1);
+         * }
+        */
+        tmpname(tmpfilename);
+#else
+        mkstemp(tmpfilename);
+#endif
 	tmpfileptr=fopen(tmpfilename, "w");
 	/*fwrite(defaults, sizeof(char), strlen(defaults), tmpfileptr); */
 

--- a/src/Third_Party/seg2segy/seg2segy_local.c
+++ b/src/Third_Party/seg2segy/seg2segy_local.c
@@ -304,7 +304,7 @@ NULL};
 	char tmpfilename[L_tmpnam];
 	FILE *tmpfileptr;
 
-	tmpnam(tmpfilename);
+	mkstemp(tmpfilename);
 	tmpfileptr=fopen(tmpfilename, "w");
 	/*fwrite(defaults, sizeof(char), strlen(defaults), tmpfileptr); */
 

--- a/src/Third_Party/seg2segy/seg2segy_local.c
+++ b/src/Third_Party/seg2segy/seg2segy_local.c
@@ -304,7 +304,21 @@ NULL};
 	char tmpfilename[L_tmpnam];
 	FILE *tmpfileptr;
 
-	mkstemp(tmpfilename);
+#ifdef __MSDOS__
+        /* MSDOS doesn't seem to have a tmpnam_s() so continue to use the tmpnam() 
+         * function.  tmpnam_s() is available on WIN32 with possible code:
+         * errno_t err;
+         * err = tmpnam_s(tmpfilename, L_tmpnam);
+         * if (err)
+         * {
+         * printf("Error occurred creating temp file.\n");
+         * exit(1);
+         * }
+        */
+        tmpname(tmpfilename);
+#else
+        mkstemp(tmpfilename);
+#endif
 	tmpfileptr=fopen(tmpfilename, "w");
 	/*fwrite(defaults, sizeof(char), strlen(defaults), tmpfileptr); */
 


### PR DESCRIPTION
Hello, 

Just a few small changes in seg2segy.c and seg2segy_local.c to replace the use of tmpnam() on non-MSDOS systems with mkstemp().  This addresses a compiler warning regarding tmpnam() being deprecated due to the risk of file name collisions which mkstemp() avoids.

I don't have an MSDOS system setup for compiling so didn't change the current behavior.  There is a commented WIN32 solution using tmpnam_s() but this function doesn't appear to be available on DOS...most folks are probably running this on Windows, anyway...

Thanks,

Tom