### PR TITLE
FIX: algorithm error on RMS calculation

### DIFF
--- a/src/su/main/attributes_parameter_estimation/sumax.c
+++ b/src/su/main/attributes_parameter_estimation/sumax.c
@@ -182,6 +182,9 @@ int      main(int argc, char **argv)
 
    gmin = gmax = tr.data[0];
    gabsmax = ABS(tr.data[0]);
+	/* pick up square of first sample for global rms calculation */
+   grmssumsq = tr.data[0] * tr.data[0];
+
 
    /* Get/Set variables for threshold mode */
    if (STREQ(mode, "thd")) {
@@ -210,6 +213,10 @@ int      main(int argc, char **argv)
       /* find local/global max/min values and their locations */
       min = max = tr.data[0];
       absmax = ABS(tr.data[0]);
+	/* pick up square of first sample for rms calculation */
+      rmssumsq = tr.data[0] * tr.data[0];
+      grmssumsq += rmssumsq;
+
      /* tr.data[0] = 0.0;	*/ /* Zero first data value */
      /* trhldmax = tr.data[0]; */
      trhldmax = 0.0 ;
@@ -240,9 +247,6 @@ int      main(int argc, char **argv)
 	    /* maximum found */
 	 }
 
-	/* pick up square of first sample for rms calculation */
-	 rmssumsq = tr.data[0]*tr.data[0];
-	 grmssumsq = tr.data[0]*tr.data[0];
 	 if (STREQ(mode, "rms")) {
 	    val = tr.data[it];
 	    rmssumsq += val * val;


### PR DESCRIPTION
Sumax calculation for RMS is not working properly. The algorithm should add tr.data[i]**2 over all samples of each trace to rmssumsq (and over the whole file to grmssumsq), but it actually resets those sums on each iteration to tr.data[0]**2. A sample calculation shows the error:

```
# suspike creates a vector [0,1,0,0], with rms=sqrt(1/4)=0.5
$ suspike nt=4 ntr=1 nspk=1 ix1=1 it1=2 offset=0 | sumax mode=rms verbose=1 
Using native byte order SU data format w/o XDR.
1 0.000000e+00
global rms = 0.000000e+00
```

After this fix, the calculation is correct:

```
suspike nt=4 ntr=1 nspk=1 ix1=1 it1=2 offset=0 | sumax mode=rms verbose=1
Using native byte order SU data format w/o XDR.
1 5.000000e-01
global rms = 5.000000e-01

```